### PR TITLE
Append new resource to resource collection to minimize impact.

### DIFF
--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -24,7 +24,7 @@ class Chef
           bin = Chef::Resource::DpkgAutostart.new('bin_file', context)
           bin.action :create
           current_resources = context.resource_collection.all_resources
-          [bin, current_resources].flatten.each_with_index do |res, i|
+          [current_resources, bin].flatten.each_with_index do |res, i|
             context.resource_collection[i] = res
           end
         end


### PR DESCRIPTION
Append the freshly created bin resource to the resource collection. Do
not prepend it. Prepend will shift indices in resource collection for
all other resources. This fixes an issue, where Chef 11.4.4 would not
find a module.

Appending will minimize the the impact of resource collection
modification. At the same time it wont harm.

This fixes an issue with Chef 11.4.4 and docker::aufs module, that I came accross.