### PR TITLE
switch to resource_collection.insert()

### DIFF
--- a/libraries/resource.rb
+++ b/libraries/resource.rb
@@ -25,7 +25,7 @@ class Chef
           bin.action :create
           current_resources = context.resource_collection.all_resources
           [bin, current_resources].flatten.each_with_index do |res, i|
-            context.resource_collection[i] = res
+            context.resource_collection.insert(res)
           end
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'dpkg_autostart'
-version '0.1.12'
+version '0.1.13'
 maintainer 'Chris Roberts'
 maintainer_email 'chrisroberts.code@gmail.com'
 description 'Control service actions initialized from dpkg'


### PR DESCRIPTION
chef 12 has deprecated the
```
resource_collection[i] = res
```
syntax and generates a WARN for every call, 90 in my case.

http://www.rubydoc.info/github/opscode/chef/Chef/ResourceCollection/