### PR TITLE
Add ChefSpec matcher for single resource

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: aptly
+# Library:: matchers
+#
+# Copyright 2016, Sean Escriva
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if defined?(ChefSpec)
+  def create_dpkg_autostart(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:dpkg_autostart, :create, resource_name)
+  end
+end


### PR DESCRIPTION
were never added, correcting that oversight now